### PR TITLE
fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 Install the UI with `go get`
 
 ```bash
-  go get github.com/hbourgeot/templdais
+  go get github.com/henrriusdev/templdais
 ```
     
 ## Demo


### PR DESCRIPTION
By following the previous instructions you are met with this error:

```
go: github.com/hbourgeot/templdais@upgrade (v1.4.6) requires github.com/hbourgeot/templdais@v1.4.6: parsing go.mod:
	module declares its path as: github.com/henrriusdev/templdais
	        but was required as: github.com/hbourgeot/templdais
```

This fixes it :)